### PR TITLE
Homing Override

### DIFF
--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -272,11 +272,27 @@ horizontal_move_z: 10.
 speed: 100
 screw_thread: CW-M4
 
-[safe_z_home]
-home_xy_position:150.5,150.5
-speed:150
-z_hop:10
-z_hop_speed:5
+
+####################################
+# Homing override for Z axis
+# When homing command includes Home Z, it is critical to ensure correct
+# extruder is selected to be centered on the bed before probing to
+# prevent bed damage. Homing process is overridden to include T0 macro
+# prior to homing process.  - Kevin Palmer
+####################################
+[homing_override]
+axes: z
+gcode:
+ T0
+ G90 ;absolute positioning
+ G1 Z10 F600
+ G28 X0
+ G28 Y0
+ G1 X130.5 Y130.5 F9000
+ G28 Z0
+ G1 Z10
+set_position_z:0
+
 
 #####################################################################
 #   Runoutsensor


### PR DESCRIPTION
I mostly print off the right extruder, and was having failed print cancellations due to a slicer end g-code issue, when I finally got it to home it would home with the right extruder active and drive it into the bed. After destroying a couple beds I created a homing override which calls T0 macro prior to homing. Works well in my testing.