### PR TITLE
Replace deprecated parameter

### DIFF
--- a/config/Sv04-works-with origin-klipper/printer.cfg
+++ b/config/Sv04-works-with origin-klipper/printer.cfg
@@ -45,7 +45,7 @@ enable_force_move: True
 kinematics: cartesian
 max_velocity: 300
 max_accel: 1000
-max_accel_to_decel: 500
+minimum_cruise_ratio: 0.5
 square_corner_velocity: 8.0
 max_z_velocity: 20
 max_z_accel: 50


### PR DESCRIPTION
In printer.cfg a deprecated parameter is used. The current pull request will replace this parameter. 