### PR TITLE
Fix toolchange Z bug

### DIFF
--- a/config/Sv04-works-with origin-klipper/IDEX_mode.cfg
+++ b/config/Sv04-works-with origin-klipper/IDEX_mode.cfg
@@ -99,7 +99,7 @@ gcode:
             # print fan speed
             _SET_PRINT_FANS_SPEED
             # restore z
-            {% if (z_safe) is defined and printer.idle_timeout.state != "Printing" %}
+            {% if (z_safe) is defined %}
                 G91
                 G1 Z-{z_safe}
                 G90
@@ -145,7 +145,7 @@ gcode:
             # print fan speed
             _SET_PRINT_FANS_SPEED
             # restore z
-            {% if (z_safe) is defined and printer.idle_timeout.state != "Printing" %}
+            {% if (z_safe) is defined %}
                 G91
                 G1 Z-{z_safe}
                 G90


### PR DESCRIPTION
Would not return to correct height directly after toolchange due to weird condition, which caused it to print perimeters in mid-air. Seems to work after removing said condition.